### PR TITLE
feat: isolate time offset per thread

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/Time.java
+++ b/common/src/main/java/org/keycloak/common/util/Time.java
@@ -17,33 +17,120 @@
 
 package org.keycloak.common.util;
 
+import java.util.ArrayDeque;
 import java.util.Date;
+import java.util.Deque;
 
 /**
+ * Time utility that allows offsetting the current time. Historically a single
+ * global offset was used which made tests interfering with each other when run
+ * concurrently.  This class now provides a thread confined offset mechanism
+ * which is also inherited by child threads.  Offsets can temporarily be pushed
+ * on a stack and are automatically restored using the returned
+ * {@link OffsetContext}.
+ *
+ * <p>Debug safeguards can be enabled by setting the system property
+ * {@code keycloak.time.debug=true}. When enabled any out of order closing of
+ * {@link OffsetContext} instances results in an {@link IllegalStateException}.
+ *
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class Time {
 
+    /** Global offset applicable to all threads. */
     private static volatile int offset;
 
+    /** Flag used to activate additional consistency checks. */
+    private static final boolean DEBUG = Boolean.getBoolean("keycloak.time.debug");
+
     /**
-     * Returns current time in seconds adjusted by adding {@link #offset) seconds.
-     * @return see description
+     * Per thread offsets.  Uses {@link InheritableThreadLocal} so that child
+     * threads see the same offset as their parents at the time of creation.
      */
-    public static int currentTime() {
-        return ((int) (System.currentTimeMillis() / 1000)) + offset;
+    private static final InheritableThreadLocal<OffsetStack> THREAD_OFFSETS = new InheritableThreadLocal<>() {
+        @Override
+        protected OffsetStack childValue(OffsetStack parentValue) {
+            return parentValue == null ? null : parentValue.copy();
+        }
+    };
+
+    /** Holds offsets for a particular thread in a stack to support nesting. */
+    private static final class OffsetStack {
+        private final Deque<Integer> stack = new ArrayDeque<>();
+        private int currentOffset = 0;
+
+        OffsetStack() {
+        }
+
+        OffsetStack(OffsetStack other) {
+            this.stack.addAll(other.stack);
+            this.currentOffset = other.currentOffset;
+        }
+
+        OffsetStack copy() {
+            return new OffsetStack(this);
+        }
+
+        void push(int value) {
+            stack.push(value);
+            currentOffset += value;
+        }
+
+        void pop(int expected) {
+            Integer top = stack.peek();
+            if (DEBUG && (top == null || top.intValue() != expected)) {
+                throw new IllegalStateException("Time offset context closed out of order");
+            }
+            int popped = stack.pop();
+            currentOffset -= popped;
+        }
+
+        int getOffset() {
+            return currentOffset;
+        }
+
+        boolean isEmpty() {
+            return stack.isEmpty();
+        }
+    }
+
+    private static int threadOffset() {
+        OffsetStack stack = THREAD_OFFSETS.get();
+        return stack == null ? 0 : stack.getOffset();
+    }
+
+    private static OffsetStack getOrCreateStack() {
+        OffsetStack stack = THREAD_OFFSETS.get();
+        if (stack == null) {
+            stack = new OffsetStack();
+            THREAD_OFFSETS.set(stack);
+        }
+        return stack;
     }
 
     /**
-     * Returns current time in milliseconds adjusted by adding {@link #offset) seconds.
-     * @return see description
+     * Returns current time in seconds adjusted by adding the global offset and
+     * any thread specific offset.
+     *
+     * @return current time with offset applied
+     */
+    public static int currentTime() {
+        return (int) (System.currentTimeMillis() / 1000) + offset + threadOffset();
+    }
+
+    /**
+     * Returns current time in milliseconds adjusted by adding the global offset
+     * and any thread specific offset.
+     *
+     * @return current time in milliseconds with offset applied
      */
     public static long currentTimeMillis() {
-        return System.currentTimeMillis() + (offset * 1000L);
+        return System.currentTimeMillis() + ((long) (offset + threadOffset())) * 1000L;
     }
 
     /**
      * Returns {@link Date} object, its value set to time
+     *
      * @param time Time in milliseconds since the epoch
      * @return see description
      */
@@ -53,6 +140,7 @@ public class Time {
 
     /**
      * Returns {@link Date} object, its value set to time
+     *
      * @param time Time in milliseconds since the epoch
      * @return see description
      */
@@ -62,6 +150,7 @@ public class Time {
 
     /**
      * Returns time in milliseconds for a time in seconds. No adjustment is made to the parameter.
+     *
      * @param time Time in seconds since the epoch
      * @return Time in milliseconds
      */
@@ -70,18 +159,78 @@ public class Time {
     }
 
     /**
-     * @return Time offset in seconds that will be added to {@link #currentTime()} and {@link #currentTimeMillis()}.
+     * @return Global time offset in seconds that will be added to all threads.
      */
     public static int getOffset() {
         return offset;
     }
 
     /**
-     * Sets time offset in seconds that will be added to {@link #currentTime()} and {@link #currentTimeMillis()}.
+     * Sets global time offset in seconds that will be added to
+     * {@link #currentTime()} and {@link #currentTimeMillis()} for all threads.
+     *
      * @param offset Offset (in seconds)
      */
     public static void setOffset(int offset) {
         Time.offset = offset;
     }
 
+    /**
+     * Returns the effective offset for the current thread, which is a
+     * combination of the global offset and any thread specific adjustments.
+     *
+     * @return effective offset for the current thread
+     */
+    public static int getCurrentOffset() {
+        return offset + threadOffset();
+    }
+
+    /**
+     * Temporarily adjusts the current thread's time offset.  The returned
+     * {@link OffsetContext} must be closed to restore the previous offset.
+     *
+     * <pre>
+     * try (OffsetContext oc = Time.withOffset(10)) {
+     *     // time is moved 10 seconds into the future for this thread and its children
+     * }
+     * </pre>
+     *
+     * @param offset offset in seconds to apply
+     * @return context that must be closed to remove the offset
+     */
+    public static OffsetContext withOffset(int offset) {
+        getOrCreateStack().push(offset);
+        return new OffsetContext(offset);
+    }
+
+    /**
+     * Context object returned from {@link #withOffset(int)} that restores the
+     * previous offset when closed.  The context is thread confined and affects
+     * only the thread that created it and its descendants.
+     */
+    public static class OffsetContext implements AutoCloseable {
+        private final int offset;
+        private boolean closed;
+
+        private OffsetContext(int offset) {
+            this.offset = offset;
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+
+            OffsetStack stack = THREAD_OFFSETS.get();
+            if (stack != null) {
+                stack.pop(offset);
+                if (stack.isEmpty()) {
+                    THREAD_OFFSETS.remove();
+                }
+            }
+            closed = true;
+        }
+    }
 }
+

--- a/common/src/test/java/org/keycloak/common/util/TimeTest.java
+++ b/common/src/test/java/org/keycloak/common/util/TimeTest.java
@@ -1,0 +1,67 @@
+package org.keycloak.common.util;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Test;
+
+/**
+ * Tests for thread local time offsets in {@link Time}.
+ */
+public class TimeTest {
+
+    @Test
+    public void testNestedOffsetsAndRestoration() {
+        long base = Time.currentTimeMillis();
+        try (Time.OffsetContext oc1 = Time.withOffset(2)) { // +2s
+            long innerBase = Time.currentTimeMillis();
+            assertTrue(innerBase - base >= 2000);
+
+            try (Time.OffsetContext oc2 = Time.withOffset(-1)) { // now +1s
+                long inner = Time.currentTimeMillis();
+                long diff = inner - base;
+                assertTrue(diff >= 1000 && diff < 2000 + 1000);
+            }
+
+            long after = Time.currentTimeMillis();
+            long diff = after - base;
+            assertTrue(diff >= 2000 && diff < 3000);
+        }
+
+        long end = Time.currentTimeMillis();
+        assertTrue(end - base < 1000); // restored
+    }
+
+    @Test
+    public void testIsolationAndInheritance() throws Exception {
+        long base = Time.currentTimeMillis();
+        CountDownLatch latch = new CountDownLatch(1);
+        final long[] unrelated = new long[1];
+
+        Thread other = new Thread(() -> {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            unrelated[0] = Time.currentTimeMillis();
+        });
+        other.start();
+
+        final long[] childTime = new long[1];
+        try (Time.OffsetContext ctx = Time.withOffset(5)) { // +5s
+            Thread child = new Thread(() -> childTime[0] = Time.currentTimeMillis());
+            child.start();
+            latch.countDown();
+            child.join();
+            other.join();
+            long parent = Time.currentTimeMillis();
+            assertTrue(Math.abs(childTime[0] - parent) < 1000); // child inherited
+            assertTrue(Math.abs(unrelated[0] - base) < 1000); // unrelated unaffected
+        }
+
+        long after = Time.currentTimeMillis();
+        assertTrue(after - base < 1000); // offset restored
+    }
+}


### PR DESCRIPTION
## Summary
- add thread-local time offset stack with debug checks
- expose OffsetContext for scoped offset changes
- test isolation, inheritance and restoration of thread offsets

## Testing
- `mvn -q -pl common -am test` *(fails: Could not transfer artifact org.jboss:jboss-parent:pom:39 from/to central (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb4eac0883269cee8e994e5984e0